### PR TITLE
Downgrade libc from 0.2.145 to 0.2.144

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.145"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "log"


### PR DESCRIPTION
This PR downgrades `libc` from `0.2.145` to `0.2.144` because `0.2.145` fails in `coreutils` CICD due to https://github.com/rust-lang/libc/issues/3264